### PR TITLE
Show a message indicating what default value was returned

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,15 @@ Metrics/BlockLength:
     - spec/**/*
     - highline_wrapper.gemspec
 
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
 Metrics/MethodLength:
   Max: 15
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,15 +52,6 @@ Metrics/BlockLength:
     - spec/**/*
     - highline_wrapper.gemspec
 
-Metrics/AbcSize:
-  Enabled: false
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-
-Metrics/PerceivedComplexity:
-  Max: 10
-
 Metrics/MethodLength:
   Max: 15
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Notes:
 * If `required` is `true`, then the `default` value will be ignored (defaults to `''`, but could be set to whatever and the code won't care... the question is required)
 * If `default` is `''` and `required` is `false`, and the user skips the question, the answer will be `''`
 * If `secret` is `true`, then the command-line will hide the user's answer behind `*`
+* If the user skips the question, a single newline representing the user's missing answer will be added automatically (no matter what `include_newline` is set to)
 * The only time that a newline is automatically entered is if the question has `secret` set to `true` and the user skips the question, in which case the HighLine client will automatically add a newline
 
 <details><summary>Examples</summary>
@@ -68,21 +69,44 @@ four
 
 > HighlineWrapper.new.ask('What is your favorite number?', {required: true})
 What is your favorite number?
+
 --- This question is required ---
 What is your favorite number?
+
 --- This question is required ---
 What is your favorite number?
+
 --- This question is required ---
 What is your favorite number?
 2
 => "2"
 
+> HighlineWrapper.new.ask('What is your favorite number?', {required: true, include_newline: true})
+What is your favorite number?
+
+--- This question is required ---
+
+What is your favorite number?
+
+--- This question is required ---
+
+What is your favorite number?
+
+--- This question is required ---
+
+What is your favorite number?
+2
+
+=> "2"
+
 > HighlineWrapper.new.ask('What is your favorite color?')
 What is your favorite color?
+
 => ""
 
 > HighlineWrapper.new.ask('What is your favorite color?', {default: 'orange'})
 What is your favorite color?
+
 => "orange"
 
 > HighlineWrapper.new.ask('Please type your private token:', {secret: true})
@@ -90,7 +114,7 @@ Please type your private token?
 ****************
 => "MY-PRIVATE-TOKEN"
 
-HighlineWrapper.new.ask('Please type your private token:', {secret: true, include_newline: true})
+> HighlineWrapper.new.ask('Please type your private token:', {secret: true, include_newline: true})
 Please type your private token:
 ****************
 
@@ -109,6 +133,11 @@ What is your private token?
 What is your private token?
 ****************
 => "MY-PRIVATE-TOKEN"
+
+> HighlineWrapper.new.ask('Please type your private token:', {secret: true})
+Please type your private token:
+****************
+=> "MY-PRIVATE-TOKEN"
 ```
 
 </details>
@@ -123,6 +152,7 @@ Question configuration options:
 Notes:
 * If `required` is `true`, the question will repeat until the user answers the question
 * If `required` is `true`, then the `default` value will be ignored (defaults to `true`, but could be set to whatever and the code won't care... the question is required)
+* If the user skips the question, a single newline representing the user's missing answer will be added automatically (no matter what `include_newline` is set to)
 * If `default` is `true` and `required` is `false`, and the user skips the question, the answer will be `true`
 
 <details><summary>Examples</summary>
@@ -138,12 +168,22 @@ Do you like Ruby?
 yes
 => true
 
+> HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {include_newline: true})
+Do you like Ruby?
+yes
+
+=> true
+
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {default: false})
 Do you like Ruby?
 => false
 
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {required: true})
 Do you like Ruby?
+
+--- This question is required ---
+Do you like Ruby?
+
 --- This question is required ---
 Do you like Ruby?
 No
@@ -176,6 +216,7 @@ Notes:
   * e.g. `{ value: 'c', index: 2 }`
 * If `with_index` is `false`, then a hash of one item will be returned
   * e.g. `{ value: 'c' }`
+* If the user skips the question, a single newline representing the user's missing answer will be added automatically (no matter what `include_newline` is set to)
 
 <details><summary>Examples</summary>
 
@@ -196,11 +237,35 @@ What is your favorite number of these?
 2
 => {:value=>"two", :index=>1}
 
+> HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: 'three', required: true, include_newline: true})
+What is your favorite number of these?
+1. one
+2. two
+3. three
+
+--- This question is required ---
+
+What is your favorite number of these?
+1. one
+2. two
+3. three
+
+--- This question is required ---
+
+What is your favorite number of these?
+1. one
+2. two
+3. three
+2
+
+=> {:value=>"two"}
+
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {with_index: true, default: 'one'})
 What is your favorite number of these?
 1. one
 2. two
 3. three
+
 => {:value=>"one", :index=>0}
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: 'three', required: true})
@@ -208,11 +273,13 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
+
 --- This question is required ---
 What is your favorite number of these?
 1. one
 2. two
 3. three
+
 --- This question is required ---
 What is your favorite number of these?
 1. one
@@ -226,6 +293,7 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
+
 => nil
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil, with_index: true})
@@ -233,6 +301,15 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
+
+=> nil
+
+> HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil, with_index: true, include_newline: true})
+What is your favorite number of these?
+1. one
+2. two
+3. three
+
 => nil
 ```
 
@@ -254,6 +331,7 @@ Notes:
   * e.g. `[{ value: 'a', index: 0 }, { value: 'c', index: 2 }]`
 * If `with_indexes` is `false`, then an hashes will be returned where each hash only has a value
   * e.g. `[{ value: 'a' }, { value: 'c' }]`
+* If the user skips the question, a single newline representing the user's missing answer will be added automatically (no matter what `include_newline` is set to)
 
 <details><summary>Examples</summary>
 
@@ -274,11 +352,21 @@ What are your favorite numbers of these?
 1, 3
 => [{:value=>"one", :index=>0}, {:value=>"three", :index=>2}]
 
+> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {with_indexes: true, include_newline: true})
+What are your favorite numbers of these?
+1. one
+2. two
+3. three
+2
+
+=> [{:value=>"two", :index=>1}]
+
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: ['two', 'three']})
 What are your favorite numbers of these?
 1. one
 2. two
 3. three
+
 => [{:value=>"two"}, {:value=>"three"}]
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {required: true, with_indexes: true})
@@ -286,6 +374,7 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
+
 --- This question is required ---
 What are your favorite numbers of these?
 1. one
@@ -299,6 +388,7 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
+
 --- This question is required ---
 What are your favorite numbers of these?
 1. one
@@ -312,13 +402,15 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
+
 => []
 
-> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: [], with_indexes: true})
+> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: [], with_indexes: true, include_newline: true})
 What are your favorite numbers of these?
 1. one
 2. two
 3. three
+
 => []
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Then, you can call its questions to receive answers. There's several configurati
 ### Open-ended questions
 
 Question configuration options:
+* `include_newline`: defaults to `false`
 * `secret`: defaults to `false`
 * `default`: defaults to `''`
 * `required`: defaults to `false`
@@ -55,6 +56,7 @@ Notes:
 * If `required` is `true`, then the `default` value will be ignored (defaults to `''`, but could be set to whatever and the code won't care... the question is required)
 * If `default` is `''` and `required` is `false`, and the user skips the question, the answer will be `''`
 * If `secret` is `true`, then the command-line will hide the user's answer behind `*`
+* The only time that a newline is automatically entered is if the question has `secret` set to `true` and the user skips the question, in which case the HighLine client will automatically add a newline
 
 <details><summary>Examples</summary>
 
@@ -62,35 +64,34 @@ Notes:
 > HighlineWrapper.new.ask('What is your favorite number?')
 What is your favorite number?
 four
-
 => "four"
 
 > HighlineWrapper.new.ask('What is your favorite number?', {required: true})
 What is your favorite number?
-
-This question is required.
-
+--- This question is required ---
 What is your favorite number?
-
-This question is required.
-
+--- This question is required ---
+What is your favorite number?
+--- This question is required ---
 What is your favorite number?
 2
-
 => "2"
 
 > HighlineWrapper.new.ask('What is your favorite color?')
 What is your favorite color?
-
 => ""
 
 > HighlineWrapper.new.ask('What is your favorite color?', {default: 'orange'})
 What is your favorite color?
-
 => "orange"
 
 > HighlineWrapper.new.ask('Please type your private token:', {secret: true})
 Please type your private token?
+****************
+=> "MY-PRIVATE-TOKEN"
+
+HighlineWrapper.new.ask('Please type your private token:', {secret: true, include_newline: true})
+Please type your private token:
 ****************
 
 => "MY-PRIVATE-TOKEN"
@@ -98,19 +99,15 @@ Please type your private token?
 > HighlineWrapper.new.ask('What is your private token?', {secret: true, required: true})
 What is your private token?
 
-This question is required.
-
+--- This question is required ---
 What is your private token?
 
-This question is required.
-
+--- This question is required ---
 What is your private token?
 
-This question is required.
-
+--- This question is required ---
 What is your private token?
 ****************
-
 => "MY-PRIVATE-TOKEN"
 ```
 
@@ -119,6 +116,7 @@ What is your private token?
 ### Yes/No questions
 
 Question configuration options:
+* `include_newline`: defaults to `false`
 * `default`: defaults to `true` (aka 'yes')
 * `required`: defaults to `false`
 
@@ -130,42 +128,33 @@ Notes:
 <details><summary>Examples</summary>
 
 ```ruby
-> HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
+> HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {include_newline: false})
 Do you like Ruby?
 no
-
 => false
 
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
 Do you like Ruby?
 yes
-
 => true
 
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {default: false})
 Do you like Ruby?
-
 => false
 
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {required: true})
 Do you like Ruby?
-
-This question is required.
-
+--- This question is required ---
 Do you like Ruby?
 No
-
 => false
 
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
 Do you like Ruby?
 uh-huh
-
-This question is required.
-
+--- This question is required ---
 Do you like Ruby?
 YES
-
 => true
 ```
 
@@ -174,6 +163,7 @@ YES
 ### Multiple choice questions
 
 Question configuration options:
+* `include_newline`: defaults to `false`
 * `with_index`: defaults to `false` (particularly handy when there may be duplicate-named but different items in the list—think Sally with ID 45 and Sally with ID 72)
 * `default`: defaults to `nil`
 * `required`: defaults to `false`
@@ -196,7 +186,6 @@ What is your favorite number of these?
 2. two
 3. three
 2
-
 => {:value=>"two"}
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {with_index: true})
@@ -205,7 +194,6 @@ What is your favorite number of these?
 2. two
 3. three
 2
-
 => {:value=>"two", :index=>1}
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {with_index: true, default: 'one'})
@@ -213,7 +201,6 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
-
 => {:value=>"one", :index=>0}
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: 'three', required: true})
@@ -221,22 +208,17 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
-
-This question is required.
-
+--- This question is required ---
 What is your favorite number of these?
 1. one
 2. two
 3. three
-
-This question is required.
-
+--- This question is required ---
 What is your favorite number of these?
 1. one
 2. two
 3. three
 2
-
 => {:value=>"two"}
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil})
@@ -244,7 +226,6 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
-
 => nil
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil, with_index: true})
@@ -252,7 +233,6 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
-
 => nil
 ```
 
@@ -261,6 +241,7 @@ What is your favorite number of these?
 ### Multiple choice "checkbox" questions
 
 Question configuration options:
+* `include_newline`: defaults to `false`
 * `with_indexes`: defaults to `false` (particularly handy when there may be duplicate-named but different items in the list—think Sally with ID 45 and Sally with ID 72)
 * `defaults`: defaults to `[]`
 * `required`: defaults to `false`
@@ -283,7 +264,6 @@ What are your favorite numbers of these?
 2. two
 3. three
 1, 3
-
 => [{:value=>"one"}, {:value=>"three"}]
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {with_indexes: true})
@@ -292,7 +272,6 @@ What are your favorite numbers of these?
 2. two
 3. three
 1, 3
-
 => [{:value=>"one", :index=>0}, {:value=>"three", :index=>2}]
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: ['two', 'three']})
@@ -300,7 +279,6 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
 => [{:value=>"two"}, {:value=>"three"}]
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {required: true, with_indexes: true})
@@ -308,15 +286,12 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
-This question is required.
-
+--- This question is required ---
 What are your favorite numbers of these?
 1. one
 2. two
 3. three
 2
-
 => [{:value=>"two", :index=>1}]
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {required: true, with_indexes: false})
@@ -324,15 +299,12 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
-This question is required.
-
+--- This question is required ---
 What are your favorite numbers of these?
 1. one
 2. two
 3. three
 1
-
 => [{:value=>"one"}]
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: []})
@@ -340,7 +312,6 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
 => []
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: [], with_indexes: true})
@@ -348,7 +319,6 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
 => []
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ Then, you can call its questions to receive answers. There's several configurati
 ### Open-ended questions
 
 Question configuration options:
-* `include_newline`: defaults to `false`
+* `indicate_default_message`: defaults to `true`
 * `secret`: defaults to `false`
 * `default`: defaults to `''`
 * `required`: defaults to `false`
 
 Notes:
+* If `indicate_default_message` is `true`, then the wrapper will tell us what the default value returned is _if_ the user skips the question
+  * If `secret` is `true`, then the wrapper _may_ automatically add a newline after a skipped answer... this is automatic from HighLine and unfortunately, out of the wrapper's control
 * If `required` is `true`, the question will repeat until the user answers the question
 * If `required` is `true`, then the `default` value will be ignored (defaults to `''`, but could be set to whatever and the code won't care... the question is required)
 * If `default` is `''` and `required` is `false`, and the user skips the question, the answer will be `''`
 * If `secret` is `true`, then the command-line will hide the user's answer behind `*`
-* If the user skips the question, a single newline representing the user's missing answer will be added automatically (no matter what `include_newline` is set to)
-* The only time that a newline is automatically entered is if the question has `secret` set to `true` and the user skips the question, in which case the HighLine client will automatically add a newline
 
 <details><summary>Examples</summary>
 
@@ -69,44 +69,36 @@ four
 
 > HighlineWrapper.new.ask('What is your favorite number?', {required: true})
 What is your favorite number?
-
 --- This question is required ---
 What is your favorite number?
-
 --- This question is required ---
 What is your favorite number?
-
 --- This question is required ---
 What is your favorite number?
 2
 => "2"
 
-> HighlineWrapper.new.ask('What is your favorite number?', {required: true, include_newline: true})
+> HighlineWrapper.new.ask('What is your favorite number?', {required: true, indicate_default_message: false})
 What is your favorite number?
-
 --- This question is required ---
-
 What is your favorite number?
-
 --- This question is required ---
-
 What is your favorite number?
+5
+=> "5"
 
---- This question is required ---
-
+> HighlineWrapper.new.ask('What is your favorite number?', {indicate_default_message: false})
 What is your favorite number?
-2
-
-=> "2"
+=> ""
 
 > HighlineWrapper.new.ask('What is your favorite color?')
 What is your favorite color?
-
+--- Default selected: EMPTY ---
 => ""
 
 > HighlineWrapper.new.ask('What is your favorite color?', {default: 'orange'})
 What is your favorite color?
-
+--- Default selected: orange ---
 => "orange"
 
 > HighlineWrapper.new.ask('Please type your private token:', {secret: true})
@@ -114,30 +106,27 @@ Please type your private token?
 ****************
 => "MY-PRIVATE-TOKEN"
 
-> HighlineWrapper.new.ask('Please type your private token:', {secret: true, include_newline: true})
+> HighlineWrapper.new.ask('Please type your private token:', {secret: true, indicate_default_message: false})
 Please type your private token:
-****************
 
-=> "MY-PRIVATE-TOKEN"
+=> ""
 
-> HighlineWrapper.new.ask('What is your private token?', {secret: true, required: true})
-What is your private token?
-
---- This question is required ---
-What is your private token?
+> HighlineWrapper.new.ask('Please type your private token:', {secret: true, required: true})
+Please type your private token:
 
 --- This question is required ---
-What is your private token?
+Please type your private token:
 
 --- This question is required ---
-What is your private token?
+Please type your private token:
 ****************
 => "MY-PRIVATE-TOKEN"
 
 > HighlineWrapper.new.ask('Please type your private token:', {secret: true})
 Please type your private token:
-****************
-=> "MY-PRIVATE-TOKEN"
+
+--- Default selected: HIDDEN ---
+=> ""
 ```
 
 </details>
@@ -145,48 +134,47 @@ Please type your private token:
 ### Yes/No questions
 
 Question configuration options:
-* `include_newline`: defaults to `false`
+* `indicate_default_message`: defaults to `true`
 * `default`: defaults to `true` (aka 'yes')
 * `required`: defaults to `false`
 
 Notes:
+* If `indicate_default_message` is `true`, then the wrapper will tell us what the default value returned is _if_ the user skips the question
 * If `required` is `true`, the question will repeat until the user answers the question
 * If `required` is `true`, then the `default` value will be ignored (defaults to `true`, but could be set to whatever and the code won't care... the question is required)
-* If the user skips the question, a single newline representing the user's missing answer will be added automatically (no matter what `include_newline` is set to)
 * If `default` is `true` and `required` is `false`, and the user skips the question, the answer will be `true`
 
 <details><summary>Examples</summary>
 
 ```ruby
-> HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {include_newline: false})
+> HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
+Do you like Ruby?
+--- Default selected: YES ---
+=> true
+
+> HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {indicate_default_message: false})
+Do you like Ruby?
+=> true
+
+> HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
 Do you like Ruby?
 no
 => false
 
-> HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
-Do you like Ruby?
-yes
-=> true
-
-> HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {include_newline: true})
-Do you like Ruby?
-yes
-
-=> true
-
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {default: false})
 Do you like Ruby?
+--- Default selected: NO ---
 => false
 
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?', {required: true})
 Do you like Ruby?
-
 --- This question is required ---
 Do you like Ruby?
-
 --- This question is required ---
 Do you like Ruby?
-No
+--- This question is required ---
+Do you like Ruby?
+no
 => false
 
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
@@ -194,7 +182,7 @@ Do you like Ruby?
 uh-huh
 --- This question is required ---
 Do you like Ruby?
-YES
+yep
 => true
 ```
 
@@ -203,12 +191,13 @@ YES
 ### Multiple choice questions
 
 Question configuration options:
-* `include_newline`: defaults to `false`
+* `indicate_default_message`: defaults to `true`
 * `with_index`: defaults to `false` (particularly handy when there may be duplicate-named but different items in the list—think Sally with ID 45 and Sally with ID 72)
 * `default`: defaults to `nil`
 * `required`: defaults to `false`
 
 Notes:
+* If `indicate_default_message` is `true`, then the wrapper will tell us what the default value returned is _if_ the user skips the question
 * If `required` is `true`, the question will repeat until the user answers the question
 * If `required` is `true`, then the `default` value will be ignored (defaults to `nil`, but could be set to whatever and the code won't care... the question is required)
 * If `default` is `nil` and `required` is `false`, and the user skips the question, the answer will be `nil`
@@ -216,7 +205,6 @@ Notes:
   * e.g. `{ value: 'c', index: 2 }`
 * If `with_index` is `false`, then a hash of one item will be returned
   * e.g. `{ value: 'c' }`
-* If the user skips the question, a single newline representing the user's missing answer will be added automatically (no matter what `include_newline` is set to)
 
 <details><summary>Examples</summary>
 
@@ -237,27 +225,22 @@ What is your favorite number of these?
 2
 => {:value=>"two", :index=>1}
 
-> HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: 'three', required: true, include_newline: true})
+> HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: 'three', required: true, indicate_default_message: false})
 What is your favorite number of these?
 1. one
 2. two
 3. three
-
 --- This question is required ---
-
 What is your favorite number of these?
 1. one
 2. two
 3. three
-
 --- This question is required ---
-
 What is your favorite number of these?
 1. one
 2. two
 3. three
 2
-
 => {:value=>"two"}
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {with_index: true, default: 'one'})
@@ -265,7 +248,14 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
+--- Default selected: 1. one ---
+=> {:value=>"one", :index=>0}
 
+> HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {with_index: true, default: 'one', indicate_default_message: false})
+What is your favorite number of these?
+1. one
+2. two
+3. three
 => {:value=>"one", :index=>0}
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: 'three', required: true})
@@ -273,43 +263,40 @@ What is your favorite number of these?
 1. one
 2. two
 3. three
-
 --- This question is required ---
 What is your favorite number of these?
 1. one
 2. two
 3. three
-
 --- This question is required ---
 What is your favorite number of these?
 1. one
 2. two
 3. three
-2
-=> {:value=>"two"}
+1
+=> {:value=>"one"}
 
 > HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil})
 What is your favorite number of these?
 1. one
 2. two
 3. three
-
+--- Default selected: EMPTY ---
 => nil
 
-> HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil, with_index: true})
+>  HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil, with_index: true})
 What is your favorite number of these?
 1. one
 2. two
 3. three
-
+--- Default selected: EMPTY ---
 => nil
 
-> HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil, with_index: true, include_newline: true})
+> HighlineWrapper.new.ask_multiple_choice('What is your favorite number of these?', ['one', 'two', 'three'], {default: nil, with_index: true, indicate_default_message: false})
 What is your favorite number of these?
 1. one
 2. two
 3. three
-
 => nil
 ```
 
@@ -318,12 +305,13 @@ What is your favorite number of these?
 ### Multiple choice "checkbox" questions
 
 Question configuration options:
-* `include_newline`: defaults to `false`
+* `indicate_default_message`: defaults to `true`
 * `with_indexes`: defaults to `false` (particularly handy when there may be duplicate-named but different items in the list—think Sally with ID 45 and Sally with ID 72)
 * `defaults`: defaults to `[]`
 * `required`: defaults to `false`
 
 Notes:
+* If `indicate_default_message` is `true`, then the wrapper will tell us what the default value returned is _if_ the user skips the question
 * If `required` is `true`, the question will repeat until the user answers the question
 * If `required` is `true`, then the `defaults` value will be ignored (this value is defaulting to `[]`, but could be set to whatever and the code won't care... the question is required)
 * If `defaults` is `[]` and `required` is `false`, then the method will return an empty array
@@ -331,7 +319,6 @@ Notes:
   * e.g. `[{ value: 'a', index: 0 }, { value: 'c', index: 2 }]`
 * If `with_indexes` is `false`, then an hashes will be returned where each hash only has a value
   * e.g. `[{ value: 'a' }, { value: 'c' }]`
-* If the user skips the question, a single newline representing the user's missing answer will be added automatically (no matter what `include_newline` is set to)
 
 <details><summary>Examples</summary>
 
@@ -352,21 +339,27 @@ What are your favorite numbers of these?
 1, 3
 => [{:value=>"one", :index=>0}, {:value=>"three", :index=>2}]
 
-> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {with_indexes: true, include_newline: true})
+> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {with_indexes: true, indicate_default_message: false})
 What are your favorite numbers of these?
 1. one
 2. two
 3. three
-2
+=> []
 
-=> [{:value=>"two", :index=>1}]
+> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {with_indexes: true})
+What are your favorite numbers of these?
+1. one
+2. two
+3. three
+--- Defaults selected: EMPTY ---
+=> []
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: ['two', 'three']})
 What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
+--- Defaults selected: 2. two, 3. three ---
 => [{:value=>"two"}, {:value=>"three"}]
 
 > HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {required: true, with_indexes: true})
@@ -374,7 +367,11 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
+--- This question is required ---
+What are your favorite numbers of these?
+1. one
+2. two
+3. three
 --- This question is required ---
 What are your favorite numbers of these?
 1. one
@@ -388,7 +385,6 @@ What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
 --- This question is required ---
 What are your favorite numbers of these?
 1. one
@@ -397,21 +393,12 @@ What are your favorite numbers of these?
 1
 => [{:value=>"one"}]
 
-> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: []})
+> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: ['two', 'three'], with_indexes: true, indicate_default_message: false})
 What are your favorite numbers of these?
 1. one
 2. two
 3. three
-
-=> []
-
-> HighlineWrapper.new.ask_checkbox("What are your favorite numbers of these?", ['one', 'two','three'], {defaults: [], with_indexes: true, include_newline: true})
-What are your favorite numbers of these?
-1. one
-2. two
-3. three
-
-=> []
+=> [{:value=>"two", :index=>1}, {:value=>"three", :index=>2}]
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Question configuration options:
 
 Notes:
 * If `indicate_default_message` is `true`, then the wrapper will tell us what the default value returned is _if_ the user skips the question
-  * If `secret` is `true`, then the wrapper _may_ automatically add a newline after a skipped answer... this is automatic from HighLine and unfortunately, out of the wrapper's control
+  * If `secret` is `true`, then the wrapper _may_ automatically add a newline after a skipped answer... this is automatic from HighLine and is, unfortunately, out of the wrapper's control
 * If `required` is `true`, the question will repeat until the user answers the question
 * If `required` is `true`, then the `default` value will be ignored (defaults to `''`, but could be set to whatever and the code won't care... the question is required)
 * If `default` is `''` and `required` is `false`, and the user skips the question, the answer will be `''`

--- a/lib/highline_wrapper.rb
+++ b/lib/highline_wrapper.rb
@@ -59,11 +59,6 @@ class HighlineWrapper
   #   with_index: whether to return the index of the selection (boolean - defaults to false)
   #   default: the default selection if the user skips the question (string - defaults to nil)
   #   required: whether the question is required or not (boolean - defaults to false)
-  #
-  # Notes:
-  #   If required == true, the question will repeat until the user answers the question
-  #   If required == true, then the default value will be ignored
-  #   If default == nil and required == false, and the user skips the question, the answer will be nil
   def ask_multiple_choice(prompt, choices, options = {})
     defaults = {
       indicate_default_message: true,

--- a/lib/highline_wrapper.rb
+++ b/lib/highline_wrapper.rb
@@ -13,6 +13,7 @@ class HighlineWrapper
   #
   # prompt: the prompt for the question (string)
   # options: various options to pass to the questions (hash)
+  #   include_newline: whether to include a newline after the user answers the question (boolean - defaults to false)
   #   secret: whether the terminal should hide the typed value (boolean - defaults to false)
   #   default: the default selection (string - defaults to '')
   #   required: whether the question is required or not (boolean - defaults to false)
@@ -22,6 +23,7 @@ class HighlineWrapper
   #  If required == true, then the default value will be ignored
   def ask(prompt, options = {})
     defaults = {
+      include_newline: false,
       secret: false,
       default: '',
       required: false
@@ -34,6 +36,7 @@ class HighlineWrapper
   #
   # prompt: the prompt for the question (string)
   # options: various options to pass to the questions (hash)
+  #   include_newline: whether to include a newline after the user answers the question (boolean - defaults to false)
   #   default: the default selection (boolean - defaults to true)
   #   required: whether the question is required or not (boolean - defaults to false)
   #
@@ -42,6 +45,7 @@ class HighlineWrapper
   #  If required == true, then the default value will be ignored
   def ask_yes_no(prompt, options = {})
     defaults = {
+      include_newline: false,
       default: true,
       required: false
     }
@@ -56,6 +60,7 @@ class HighlineWrapper
   # prompt: the prompt for the question (string)
   # choices: a list of string options (array) (e.g. [ 'a', 'b', 'c' ])
   # options: various options to pass to the questions (hash)
+  #   include_newline: whether to include a newline after the user answers the question (boolean - defaults to false)
   #   with_index: whether to return the index of the selection (boolean - defaults to false)
   #   default: the default selection if the user skips the question (string - defaults to nil)
   #   required: whether the question is required or not (boolean - defaults to false)
@@ -66,6 +71,7 @@ class HighlineWrapper
   #   If default == nil and required == false, and the user skips the question, the answer will be nil
   def ask_multiple_choice(prompt, choices, options = {})
     defaults = {
+      include_newline: false,
       with_index: false,
       default: nil,
       required: false
@@ -81,6 +87,7 @@ class HighlineWrapper
   # prompt: the prompt for the question (string)
   # choices: a list of string options (array) (e.g. [ 'a', 'b', 'c' ])
   # options: various options to pass to the questions (hash)
+  #   include_newline: whether to include a newline after the user answers the question (boolean - defaults to false)
   #   with_indexes: whether to return the indexes of the selections (boolean - defaults to false)
   #   defaults: the default selections if the user skips the question (array - defaults to [])
   #   required: whether the question is required or not (boolean - defaults to false)
@@ -91,6 +98,7 @@ class HighlineWrapper
   #   If defaults == [] and required == false, then the method will return an empty array
   def ask_checkbox(prompt, choices, options = {})
     defaults = {
+      include_newline: false,
       with_indexes: false,
       defaults: [],
       required: false

--- a/lib/highline_wrapper.rb
+++ b/lib/highline_wrapper.rb
@@ -13,17 +13,14 @@ class HighlineWrapper
   #
   # prompt: the prompt for the question (string)
   # options: various options to pass to the questions (hash)
-  #   include_newline: whether to include a newline after the user answers the question (boolean - defaults to false)
+  #   indicate_default_message: whether to tell the terminal what the default value selected is if the question
+  #     is skipped (boolean - defaults to true)
   #   secret: whether the terminal should hide the typed value (boolean - defaults to false)
   #   default: the default selection (string - defaults to '')
   #   required: whether the question is required or not (boolean - defaults to false)
-  #
-  # Notes:
-  #  If required == true, the question will repeat until the user answers the question
-  #  If required == true, then the default value will be ignored
   def ask(prompt, options = {})
     defaults = {
-      include_newline: false,
+      indicate_default_message: true,
       secret: false,
       default: '',
       required: false
@@ -36,16 +33,13 @@ class HighlineWrapper
   #
   # prompt: the prompt for the question (string)
   # options: various options to pass to the questions (hash)
-  #   include_newline: whether to include a newline after the user answers the question (boolean - defaults to false)
+  #   indicate_default_message: whether to tell the terminal what the default value selected is if the question
+  #     is skipped (boolean - defaults to true)
   #   default: the default selection (boolean - defaults to true)
   #   required: whether the question is required or not (boolean - defaults to false)
-  #
-  # Notes:
-  #  If required == true, the question will repeat until the user answers the question
-  #  If required == true, then the default value will be ignored
   def ask_yes_no(prompt, options = {})
     defaults = {
-      include_newline: false,
+      indicate_default_message: true,
       default: true,
       required: false
     }
@@ -60,7 +54,8 @@ class HighlineWrapper
   # prompt: the prompt for the question (string)
   # choices: a list of string options (array) (e.g. [ 'a', 'b', 'c' ])
   # options: various options to pass to the questions (hash)
-  #   include_newline: whether to include a newline after the user answers the question (boolean - defaults to false)
+  #   indicate_default_message: whether to tell the terminal what the default value selected is if the question
+  #     is skipped (boolean - defaults to true)
   #   with_index: whether to return the index of the selection (boolean - defaults to false)
   #   default: the default selection if the user skips the question (string - defaults to nil)
   #   required: whether the question is required or not (boolean - defaults to false)
@@ -71,7 +66,7 @@ class HighlineWrapper
   #   If default == nil and required == false, and the user skips the question, the answer will be nil
   def ask_multiple_choice(prompt, choices, options = {})
     defaults = {
-      include_newline: false,
+      indicate_default_message: true,
       with_index: false,
       default: nil,
       required: false
@@ -87,18 +82,14 @@ class HighlineWrapper
   # prompt: the prompt for the question (string)
   # choices: a list of string options (array) (e.g. [ 'a', 'b', 'c' ])
   # options: various options to pass to the questions (hash)
-  #   include_newline: whether to include a newline after the user answers the question (boolean - defaults to false)
+  #   indicate_default_message: whether to tell the terminal what the default value selected is if the question
+  #     is skipped (boolean - defaults to true)
   #   with_indexes: whether to return the indexes of the selections (boolean - defaults to false)
   #   defaults: the default selections if the user skips the question (array - defaults to [])
   #   required: whether the question is required or not (boolean - defaults to false)
-  #
-  # Notes:
-  #   If required == true, the question will repeat until the user answers the question
-  #   If required == true, then the defaults value will be ignored
-  #   If defaults == [] and required == false, then the method will return an empty array
   def ask_checkbox(prompt, choices, options = {})
     defaults = {
-      include_newline: false,
+      indicate_default_message: true,
       with_indexes: false,
       defaults: [],
       required: false

--- a/lib/highline_wrapper/checkbox_question.rb
+++ b/lib/highline_wrapper/checkbox_question.rb
@@ -7,19 +7,29 @@ class HighlineWrapper
     class << self
       def ask(prompt, choices, options)
         indices = ask_highline(format_options(prompt, choices))
-        puts if options[:include_newline] || indices.empty?
 
         return format_multiple_selections(choices, indices, options[:with_indexes]) unless indices.empty?
         return recurse(prompt, choices, options) if options[:required]
-        return options[:defaults] if options[:defaults].empty?
+        return return_empty_defaults(options) if options[:defaults].empty?
 
-        format_multiple_selections(choices, options[:defaults].map { |d| choices.index(d) }, options[:with_indexes])
+        return_defaults(choices, options)
       end
 
       private def ask_highline(prompt)
         indices = []
         super(prompt).to_s.split(',').each { |i| indices << i.strip.to_i - 1 }
         indices
+      end
+
+      private def return_defaults(choices, options)
+        options[:default_indexes] = options[:defaults].map { |d| choices.index(d) }
+        print_default_message(options, choices) if options[:indicate_default_message]
+        format_multiple_selections(choices, options[:default_indexes], options[:with_indexes])
+      end
+
+      private def print_default_message(options, choices)
+        defaults = options[:default_indexes].map { |i| "#{i + 1}. #{choices[i]}".strip }.join(', ')
+        puts "--- Defaults selected: #{defaults} ---"
       end
 
       private def format_multiple_selections(choices, indices, with_indexes)

--- a/lib/highline_wrapper/checkbox_question.rb
+++ b/lib/highline_wrapper/checkbox_question.rb
@@ -7,7 +7,7 @@ class HighlineWrapper
     class << self
       def ask(prompt, choices, options)
         indices = ask_highline(format_options(prompt, choices))
-        puts
+        puts if options[:include_newline]
 
         return format_multiple_selections(choices, indices, options[:with_indexes]) unless indices.empty?
         return recurse(prompt, choices, options) if options[:required]

--- a/lib/highline_wrapper/checkbox_question.rb
+++ b/lib/highline_wrapper/checkbox_question.rb
@@ -7,7 +7,7 @@ class HighlineWrapper
     class << self
       def ask(prompt, choices, options)
         indices = ask_highline(format_options(prompt, choices))
-        puts if options[:include_newline]
+        puts if options[:include_newline] || indices.empty?
 
         return format_multiple_selections(choices, indices, options[:with_indexes]) unless indices.empty?
         return recurse(prompt, choices, options) if options[:required]

--- a/lib/highline_wrapper/multiple_choice_question.rb
+++ b/lib/highline_wrapper/multiple_choice_question.rb
@@ -7,13 +7,22 @@ class HighlineWrapper
     class << self
       def ask(prompt, choices, options)
         index = ask_highline(format_options(prompt, choices)).to_i - 1
-        puts if options[:include_newline] || index == -1
 
         return format_selection(choices, index, options[:with_index]) unless index == -1
         return recurse(prompt, choices, options) if options[:required]
-        return nil if options[:default].nil?
+        return return_empty_defaults(options) if options[:default].nil?
 
-        format_selection(choices, choices.index(options[:default]), options[:with_index])
+        return_defaults(choices, options)
+      end
+
+      private def return_defaults(choices, options)
+        options[:default_index] = choices.index(options[:default])
+        print_default_message(options) if options[:indicate_default_message]
+        format_selection(choices, options[:default_index], options[:with_index])
+      end
+
+      private def print_default_message(options)
+        puts "--- Default selected: #{options[:default_index] + 1}. #{options[:default]} ---"
       end
     end
   end

--- a/lib/highline_wrapper/multiple_choice_question.rb
+++ b/lib/highline_wrapper/multiple_choice_question.rb
@@ -7,7 +7,7 @@ class HighlineWrapper
     class << self
       def ask(prompt, choices, options)
         index = ask_highline(format_options(prompt, choices)).to_i - 1
-        puts
+        puts if options[:include_newline]
 
         return format_selection(choices, index, options[:with_index]) unless index == -1
         return recurse(prompt, choices, options) if options[:required]

--- a/lib/highline_wrapper/multiple_choice_question.rb
+++ b/lib/highline_wrapper/multiple_choice_question.rb
@@ -7,7 +7,7 @@ class HighlineWrapper
     class << self
       def ask(prompt, choices, options)
         index = ask_highline(format_options(prompt, choices)).to_i - 1
-        puts if options[:include_newline]
+        puts if options[:include_newline] || index == -1
 
         return format_selection(choices, index, options[:with_index]) unless index == -1
         return recurse(prompt, choices, options) if options[:required]

--- a/lib/highline_wrapper/open_ended_question.rb
+++ b/lib/highline_wrapper/open_ended_question.rb
@@ -8,15 +8,19 @@ class HighlineWrapper
       def ask(prompt, options)
         answer = ask_highline(prompt, secret: options[:secret]).to_s
 
-        if (!options[:secret] && (options[:include_newline] || answer.empty?)) ||
-           (options[:secret] && (options[:include_newline] && !answer.empty?))
-          puts
-        end
-
         return answer unless answer.empty?
         return recurse(prompt, nil, options) if options[:required]
 
+        print_default_message(options) if options[:indicate_default_message]
         options[:default]
+      end
+
+      private def print_default_message(options)
+        if !options[:secret]
+          puts "--- Default selected: #{options[:default].empty? ? 'EMPTY' : options[:default]} ---"
+        elsif options[:secret]
+          puts '--- Default selected: HIDDEN ---'
+        end
       end
     end
   end

--- a/lib/highline_wrapper/open_ended_question.rb
+++ b/lib/highline_wrapper/open_ended_question.rb
@@ -8,10 +8,9 @@ class HighlineWrapper
       def ask(prompt, options)
         answer = ask_highline(prompt, secret: options[:secret]).to_s
 
-        if !options[:secret] && (options[:include_newline] || answer.empty?)
+        if (!options[:secret] && (options[:include_newline] || answer.empty?)) ||
+           (options[:secret] && (options[:include_newline] && !answer.empty?))
           puts
-        elsif options[:secret]
-          puts if options[:include_newline] && !answer.empty?
         end
 
         return answer unless answer.empty?

--- a/lib/highline_wrapper/open_ended_question.rb
+++ b/lib/highline_wrapper/open_ended_question.rb
@@ -7,7 +7,7 @@ class HighlineWrapper
     class << self
       def ask(prompt, options)
         answer = ask_highline(prompt, secret: options[:secret]).to_s
-        puts unless answer.empty? && options[:secret]
+        puts if options[:include_newline]
 
         return answer unless answer.empty?
         return recurse(prompt, nil, options) if options[:required]

--- a/lib/highline_wrapper/open_ended_question.rb
+++ b/lib/highline_wrapper/open_ended_question.rb
@@ -7,7 +7,12 @@ class HighlineWrapper
     class << self
       def ask(prompt, options)
         answer = ask_highline(prompt, secret: options[:secret]).to_s
-        puts if options[:include_newline]
+
+        if !options[:secret] && (options[:include_newline] || answer.empty?)
+          puts
+        elsif options[:secret]
+          puts if options[:include_newline] && !answer.empty?
+        end
 
         return answer unless answer.empty?
         return recurse(prompt, nil, options) if options[:required]

--- a/lib/highline_wrapper/question.rb
+++ b/lib/highline_wrapper/question.rb
@@ -29,7 +29,7 @@ class HighlineWrapper
 
       def return_empty_defaults(options)
         puts '--- Default selected: EMPTY ---' if options[:indicate_default_message]
-        options[:defaults]
+        options[:defaults] || options[:default]
       end
 
       private def highline

--- a/lib/highline_wrapper/question.rb
+++ b/lib/highline_wrapper/question.rb
@@ -24,8 +24,12 @@ class HighlineWrapper
 
       def recurse(prompt, choices, options)
         puts '--- This question is required ---'
-        puts if options[:include_newline]
         choices.nil? ? ask(prompt, options) : ask(prompt, choices, options)
+      end
+
+      def return_empty_defaults(options)
+        puts '--- Default selected: EMPTY ---' if options[:indicate_default_message]
+        options[:defaults]
       end
 
       private def highline

--- a/lib/highline_wrapper/question.rb
+++ b/lib/highline_wrapper/question.rb
@@ -23,7 +23,7 @@ class HighlineWrapper
       end
 
       def recurse(prompt, choices, options)
-        puts "--- This question is required ---"
+        puts '--- This question is required ---'
         puts if options[:include_newline]
         choices.nil? ? ask(prompt, options) : ask(prompt, choices, options)
       end

--- a/lib/highline_wrapper/question.rb
+++ b/lib/highline_wrapper/question.rb
@@ -23,7 +23,8 @@ class HighlineWrapper
       end
 
       def recurse(prompt, choices, options)
-        puts "This question is required.\n\n"
+        puts "--- This question is required ---"
+        puts if options[:include_newline]
         choices.nil? ? ask(prompt, options) : ask(prompt, choices, options)
       end
 

--- a/lib/highline_wrapper/version.rb
+++ b/lib/highline_wrapper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class HighlineWrapper
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/lib/highline_wrapper/yes_no_question.rb
+++ b/lib/highline_wrapper/yes_no_question.rb
@@ -7,7 +7,7 @@ class HighlineWrapper
     class << self
       def ask(prompt, options)
         answer = ask_highline(prompt).to_s.downcase
-        puts if options[:include_newline]
+        puts if options[:include_newline] || answer.empty?
 
         return parse(answer, prompt, options) unless answer.empty?
         return recurse(prompt, nil, options) if options[:required]

--- a/lib/highline_wrapper/yes_no_question.rb
+++ b/lib/highline_wrapper/yes_no_question.rb
@@ -7,19 +7,23 @@ class HighlineWrapper
     class << self
       def ask(prompt, options)
         answer = ask_highline(prompt).to_s.downcase
-        puts if options[:include_newline] || answer.empty?
 
         return parse(answer, prompt, options) unless answer.empty?
         return recurse(prompt, nil, options) if options[:required]
 
+        print_default_message(options) if options[:indicate_default_message]
         options[:default]
       end
 
-      def parse(answer, prompt, options)
+      private def parse(answer, prompt, options)
         return true if answer.include?('y')
         return false if answer.include?('n')
 
         recurse(prompt, nil, options)
+      end
+
+      private def print_default_message(options)
+        puts "--- Default selected: #{options[:default] ? 'YES' : 'NO'} ---"
       end
     end
   end

--- a/lib/highline_wrapper/yes_no_question.rb
+++ b/lib/highline_wrapper/yes_no_question.rb
@@ -7,7 +7,7 @@ class HighlineWrapper
     class << self
       def ask(prompt, options)
         answer = ask_highline(prompt).to_s.downcase
-        puts
+        puts if options[:include_newline]
 
         return parse(answer, prompt, options) unless answer.empty?
         return recurse(prompt, nil, options) if options[:required]

--- a/spec/highline_wrapper/checkbox_question_spec.rb
+++ b/spec/highline_wrapper/checkbox_question_spec.rb
@@ -44,6 +44,12 @@ describe HighlineWrapper::CheckboxQuestion do
       resp = subject.ask(Faker::Lorem.sentence, choices, options)
       expect(resp).to eq([])
     end
+
+    it 'should call the return empty defaults if the user skips' do
+      allow(highline).to receive(:ask).and_return('')
+      expect(subject).to receive(:return_empty_defaults)
+      subject.ask(Faker::Lorem.sentence, choices, options)
+    end
   end
 
   context 'with required set to true' do
@@ -97,6 +103,7 @@ describe HighlineWrapper::CheckboxQuestion do
       context 'with defaults set' do
         let(:options) do
           {
+            indicate_default_message: true,
             with_indexes: false,
             defaults: ['two'],
             required: false
@@ -113,6 +120,31 @@ describe HighlineWrapper::CheckboxQuestion do
           allow(highline).to receive(:ask).and_return('')
           resp = subject.ask(Faker::Lorem.sentence, choices, options)
           expect(resp).to eq([{ value: 'two' }])
+        end
+
+        it 'should call to return the defaults if the user skips' do
+          allow(highline).to receive(:ask).and_return('')
+          expect(subject).to receive(:return_defaults).and_call_original
+          expect(subject).to receive(:puts)
+          subject.ask(Faker::Lorem.sentence, choices, options)
+        end
+
+        context 'when the indicate_default_message is false' do
+          let(:options) do
+            {
+              indicate_default_message: false,
+              with_indexes: false,
+              defaults: ['two'],
+              required: false
+            }
+          end
+
+          it 'should call to return the defaults if the user skips' do
+            allow(highline).to receive(:ask).and_return('')
+            expect(subject).to receive(:return_defaults)
+            expect(subject).not_to receive(:puts)
+            subject.ask(Faker::Lorem.sentence, choices, options)
+          end
         end
       end
 
@@ -181,6 +213,12 @@ describe HighlineWrapper::CheckboxQuestion do
           allow(highline).to receive(:ask).and_return('')
           resp = subject.ask(Faker::Lorem.sentence, choices, options)
           expect(resp).to eq([])
+        end
+
+        it 'should call the return empty defaults message' do
+          allow(highline).to receive(:ask).and_return('')
+          expect(subject).to receive(:return_empty_defaults)
+          subject.ask(Faker::Lorem.sentence, choices, options)
         end
       end
     end

--- a/spec/highline_wrapper/multiple_choice_question_spec.rb
+++ b/spec/highline_wrapper/multiple_choice_question_spec.rb
@@ -44,6 +44,12 @@ describe HighlineWrapper::MultipleChoiceQuestion do
       resp = subject.ask(Faker::Lorem.sentence, choices, options)
       expect(resp).to eq(nil)
     end
+
+    it 'should call the return empty defaults if the user skips' do
+      allow(highline).to receive(:ask).and_return('')
+      expect(subject).to receive(:return_empty_defaults)
+      subject.ask(Faker::Lorem.sentence, choices, options)
+    end
   end
 
   context 'with required set to true' do
@@ -97,6 +103,7 @@ describe HighlineWrapper::MultipleChoiceQuestion do
       context 'with default set' do
         let(:options) do
           {
+            indicate_default_message: true,
             with_index: false,
             default: 'two',
             required: false
@@ -113,6 +120,31 @@ describe HighlineWrapper::MultipleChoiceQuestion do
           allow(highline).to receive(:ask).and_return(0)
           resp = subject.ask(Faker::Lorem.sentence, choices, options)
           expect(resp).to eq({ value: 'two' })
+        end
+
+        it 'should call to return the defaults if the user skips' do
+          allow(highline).to receive(:ask).and_return(0)
+          expect(subject).to receive(:return_defaults).and_call_original
+          expect(subject).to receive(:puts)
+          subject.ask(Faker::Lorem.sentence, choices, options)
+        end
+
+        context 'when the indicate_default_message is false' do
+          let(:options) do
+            {
+              indicate_default_message: false,
+              with_indexes: false,
+              default: 'two',
+              required: false
+            }
+          end
+
+          it 'should call to return the defaults if the user skips' do
+            allow(highline).to receive(:ask).and_return(0)
+            expect(subject).to receive(:return_defaults)
+            expect(subject).not_to receive(:puts)
+            subject.ask(Faker::Lorem.sentence, choices, options)
+          end
         end
       end
 
@@ -181,6 +213,12 @@ describe HighlineWrapper::MultipleChoiceQuestion do
           allow(highline).to receive(:ask).and_return(0)
           resp = subject.ask(Faker::Lorem.sentence, choices, options)
           expect(resp).to eq(nil)
+        end
+
+        it 'should call the return empty defaults message' do
+          allow(highline).to receive(:ask).and_return(0)
+          expect(subject).to receive(:return_empty_defaults)
+          subject.ask(Faker::Lorem.sentence, choices, options)
         end
       end
     end

--- a/spec/highline_wrapper/open_ended_question_spec.rb
+++ b/spec/highline_wrapper/open_ended_question_spec.rb
@@ -21,6 +21,7 @@ describe HighlineWrapper::OpenEndedQuestion do
   context 'with the options as defaults' do
     let(:options) do
       {
+        indicate_default_message: true,
         secret: false,
         default: '',
         required: false
@@ -43,6 +44,12 @@ describe HighlineWrapper::OpenEndedQuestion do
       allow(highline).to receive(:ask).and_return('')
       resp = subject.ask(Faker::Lorem.sentence, options)
       expect(resp).to eq('')
+    end
+
+    it 'should call to print the default message' do
+      allow(highline).to receive(:ask).and_return('')
+      expect(subject).to receive(:print_default_message)
+      subject.ask(Faker::Lorem.sentence, options)
     end
   end
 
@@ -73,6 +80,7 @@ describe HighlineWrapper::OpenEndedQuestion do
     let(:default_string) { Faker::Lorem.sentence }
     let(:options) do
       {
+        indicate_default_message: false,
         secret: false,
         default: default_string,
         required: false
@@ -89,6 +97,12 @@ describe HighlineWrapper::OpenEndedQuestion do
     it 'should return the default value the user skips' do
       allow(highline).to receive(:ask).and_return('')
       expect(subject.ask(Faker::Lorem.sentence, options)).to eq(default_string)
+    end
+
+    it 'should not call to print the default message' do
+      allow(highline).to receive(:ask).and_return('')
+      expect(subject).not_to receive(:print_default_message)
+      subject.ask(Faker::Lorem.sentence, options)
     end
   end
 end

--- a/spec/highline_wrapper/question_spec.rb
+++ b/spec/highline_wrapper/question_spec.rb
@@ -60,4 +60,55 @@ describe HighlineWrapper::Question do
       end
     end
   end
+
+  describe '#should print out a message indicating EMPTY was selected, and return the defaults' do
+    context 'when default message is true' do
+      let(:options) do
+        {
+          defaults: :default,
+          indicate_default_message: true
+        }
+      end
+
+      it 'should return the default in the options' do
+        expect(subject.send(:return_empty_defaults, options)).to eq(:default)
+      end
+
+      it 'should puts a message' do
+        expect(subject).to receive(:puts)
+        expect(subject.send(:return_empty_defaults, options)).to eq(:default)
+      end
+    end
+
+    context 'when default message is false' do
+      let(:options) do
+        {
+          defaults: :default,
+          indicate_default_message: false
+        }
+      end
+
+      it 'should return the default in the options' do
+        expect(subject.send(:return_empty_defaults, options)).to eq(:default)
+      end
+
+      it 'should not puts a message' do
+        expect(subject).not_to receive(:puts)
+        expect(subject.send(:return_empty_defaults, options)).to eq(:default)
+      end
+    end
+
+    context 'when a singular default is present, but not plural' do
+      let(:options) do
+        {
+          default: :default,
+          indicate_default_message: false
+        }
+      end
+
+      it 'should return the default in the options' do
+        expect(subject.send(:return_empty_defaults, options)).to eq(:default)
+      end
+    end
+  end
 end

--- a/spec/highline_wrapper/yes_no_question_spec.rb
+++ b/spec/highline_wrapper/yes_no_question_spec.rb
@@ -21,6 +21,7 @@ describe HighlineWrapper::YesNoQuestion do
   context 'with the options as defaults' do
     let(:options) do
       {
+        indicate_default_message: true,
         default: true,
         required: false
       }
@@ -41,6 +42,12 @@ describe HighlineWrapper::YesNoQuestion do
       allow(highline).to receive(:ask).and_return('')
       resp = subject.ask(Faker::Lorem.sentence, options)
       expect(resp).to eq(true)
+    end
+
+    it 'should call to print the default message' do
+      allow(highline).to receive(:ask).and_return('')
+      expect(subject).to receive(:print_default_message)
+      subject.ask(Faker::Lorem.sentence, options)
     end
   end
 
@@ -68,6 +75,7 @@ describe HighlineWrapper::YesNoQuestion do
   context 'with required set to false' do
     let(:options) do
       {
+        indicate_default_message: false,
         default: false,
         required: false
       }
@@ -83,6 +91,12 @@ describe HighlineWrapper::YesNoQuestion do
       allow(highline).to receive(:ask).and_return('')
       resp = subject.ask(Faker::Lorem.sentence, options)
       expect(resp).to eq(false)
+    end
+
+    it 'should not call to print the default message' do
+      allow(highline).to receive(:ask).and_return('')
+      expect(subject).not_to receive(:print_default_message)
+      subject.ask(Faker::Lorem.sentence, options)
     end
   end
 end


### PR DESCRIPTION
## Changes

If any question is skipped, then show a message that says what the default value was, aka what was returned. If the message is empty, then indicate that by showing `EMPTY`. If it's a secret question, then indicate it was `HIDDEN`. But all of this should be an option, so there's a new configuration option called `indicate_default_message` which is turned onto `true` by default, but each question can override this.

This default message should replace a bunch of extra newlines all over the place, which was cluttering up terminals.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.
