### PR TITLE
Require specific responses for yes/no questions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - vendor/**/*
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Notes:
 * If `required` is `true`, the question will repeat until the user answers the question
 * If `required` is `true`, then the `default` value will be ignored (defaults to `true`, but could be set to whatever and the code won't care... the question is required)
 * If `default` is `true` and `required` is `false`, and the user skips the question, the answer will be `true`
+* The response to the question MUST be given either as `y`/`n`/`yes`/`no` or with any capitalization... anything else given as a response will be unparseable
 
 <details><summary>Examples</summary>
 
@@ -174,7 +175,7 @@ Do you like Ruby?
 Do you like Ruby?
 --- This question is required ---
 Do you like Ruby?
-no
+N
 => false
 
 > HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
@@ -182,7 +183,15 @@ Do you like Ruby?
 uh-huh
 --- This question is required ---
 Do you like Ruby?
+YES
+=> true
+
+> HighlineWrapper.new.ask_yes_no('Do you like Ruby?')
+Do you like Ruby?
 yep
+--- This question is required ---
+Do you like Ruby?
+yes
 => true
 ```
 

--- a/lib/highline_wrapper/version.rb
+++ b/lib/highline_wrapper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class HighlineWrapper
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/lib/highline_wrapper/yes_no_question.rb
+++ b/lib/highline_wrapper/yes_no_question.rb
@@ -16,8 +16,8 @@ class HighlineWrapper
       end
 
       private def parse(answer, prompt, options)
-        return true if answer.include?('yes')
-        return false if answer.include?('no')
+        return true if answer.length == 3 && answer.include?('yes')
+        return false if answer.length == 2 && answer.include?('no')
         return true if answer.length == 1 && answer.include?('y')
         return false if answer.length == 1 && answer.include?('n')
 

--- a/lib/highline_wrapper/yes_no_question.rb
+++ b/lib/highline_wrapper/yes_no_question.rb
@@ -16,12 +16,14 @@ class HighlineWrapper
       end
 
       private def parse(answer, prompt, options)
-        return true if answer == 'yes'
-        return false if answer == 'no'
-        return true if answer == 'y'
-        return false if answer == 'n'
-
-        recurse(prompt, nil, options)
+        case answer
+        when 'yes', 'y'
+          true
+        when 'no', 'n'
+          false
+        else
+          recurse(prompt, nil, options)
+        end
       end
 
       private def print_default_message(options)

--- a/lib/highline_wrapper/yes_no_question.rb
+++ b/lib/highline_wrapper/yes_no_question.rb
@@ -16,10 +16,10 @@ class HighlineWrapper
       end
 
       private def parse(answer, prompt, options)
-        return true if answer.length == 3 && answer.include?('yes')
-        return false if answer.length == 2 && answer.include?('no')
-        return true if answer.length == 1 && answer.include?('y')
-        return false if answer.length == 1 && answer.include?('n')
+        return true if answer == 'yes'
+        return false if answer == 'no'
+        return true if answer == 'y'
+        return false if answer == 'n'
 
         recurse(prompt, nil, options)
       end

--- a/lib/highline_wrapper/yes_no_question.rb
+++ b/lib/highline_wrapper/yes_no_question.rb
@@ -16,8 +16,10 @@ class HighlineWrapper
       end
 
       private def parse(answer, prompt, options)
-        return true if answer.include?('y')
-        return false if answer.include?('n')
+        return true if answer.include?('yes')
+        return false if answer.include?('no')
+        return true if answer.length == 1 && answer.include?('y')
+        return false if answer.length == 1 && answer.include?('n')
 
         recurse(prompt, nil, options)
       end

--- a/spec/highline_wrapper/yes_no_question_spec.rb
+++ b/spec/highline_wrapper/yes_no_question_spec.rb
@@ -52,7 +52,7 @@ describe HighlineWrapper::YesNoQuestion do
 
     it 'should recurse if the answer given is unparseable' do
       allow(highline).to receive(:ask).and_return('yep', 'yessss', 'yes')
-      expect(subject).to receive(:recurse).at_least(2).times.and_call_original
+      expect(subject).to receive(:recurse).exactly(2).times.and_call_original
       subject.ask(Faker::Lorem.sentence, options)
     end
   end

--- a/spec/highline_wrapper/yes_no_question_spec.rb
+++ b/spec/highline_wrapper/yes_no_question_spec.rb
@@ -28,7 +28,7 @@ describe HighlineWrapper::YesNoQuestion do
     end
 
     it 'should ask the highline client ask' do
-      expect(highline).to receive(:ask)
+      expect(highline).to receive(:ask).and_return('Y')
       subject.ask(Faker::Lorem.sentence, options)
     end
 
@@ -47,6 +47,12 @@ describe HighlineWrapper::YesNoQuestion do
     it 'should call to print the default message' do
       allow(highline).to receive(:ask).and_return('')
       expect(subject).to receive(:print_default_message)
+      subject.ask(Faker::Lorem.sentence, options)
+    end
+
+    it 'should recurse if the answer given is unparseable' do
+      allow(highline).to receive(:ask).and_return('yep', 'yessss', 'yes')
+      expect(subject).to receive(:recurse).at_least(2).times.and_call_original
       subject.ask(Faker::Lorem.sentence, options)
     end
   end


### PR DESCRIPTION
## Changes

When answering a yes or no question, specifically require the user to type `n` or `y` for one-letter responses, or `yes` or `no` for multi-letter responses.

What was happening (even for me) was that I was jumping the ball. I'd type a longer sentence or title response, usually answering what will be a follow-up open-ended question, but answering it early as the yes/no question.

And if my longer sentence or title response had any `n` or `y` character, then the wrapper would consider that as an answer for the question. And if the title response had both a `n` and a `y`, then it'd consider the `y` first and answer as yes.

So now, the user must specifically say `yes` or `no` (and the wrapper now does a full string `==` check, not an `include?`, so `nonono` would be unparseable) OR they must respond exactly `y` or `n`. Anything else given is unparseable.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
