### PR TITLE
Remove extra development dependency

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -2,6 +2,6 @@
 
 guard :rspec, cmd: 'bundle exec rspec', all_on_start: true do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { 'spec' }
 end

--- a/highline_wrapper.gemspec
+++ b/highline_wrapper.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |gem|
   gem.name                  = 'highline_wrapper'
   gem.version               = HighlineWrapper::VERSION
   gem.authors               = ['Emma Sax']
-  gem.summary               = 'A little wrapper for HighLine'
+  gem.summary               = 'A little HighLine wrapper'
   gem.description           = 'Making it easier to ask simple questions, such as multiple choice ' \
-                              'questions, yes/no questions, etc, using HighLine'
+                              'questions, yes/no questions, etc, using HighLine.'
   gem.homepage              = 'https://github.com/emmahsax/highline_wrapper'
   gem.license               = 'BSD-3-Clause'
   gem.required_ruby_version = '>= 1.9.3'
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'faker', '~> 2.15'
   gem.add_development_dependency 'guard-rspec', '~> 4.3'
   gem.add_development_dependency 'pry', '~> 0.13'
-  gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency 'rspec', '~> 3.9'
   gem.add_development_dependency 'rubocop', '~> 1.10'
 end

--- a/lib/highline_wrapper/version.rb
+++ b/lib/highline_wrapper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class HighlineWrapper
-  VERSION = '1.2.3'
+  VERSION = '1.3.0'
 end

--- a/lib/highline_wrapper/version.rb
+++ b/lib/highline_wrapper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class HighlineWrapper
-  VERSION = '1.2.2'
+  VERSION = '1.2.3'
 end


### PR DESCRIPTION
## Changes

* Remove the `rake` development dependency because it's not really required
* Correctly watch the `lib` files when using Guard
* Update the gem's description and summary

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
